### PR TITLE
Stable sorting of indices

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "delaunay-fast",
   "main": "delaunay.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/ironwallaby/delaunay",
   "authors": [
     "J. T. L."

--- a/delaunay.js
+++ b/delaunay.js
@@ -120,14 +120,16 @@ var Delaunay;
           vertices[i] = vertices[i][key];
 
       /* Make an array of indices into the vertex array, sorted by the
-       * vertices' x-position. */
+       * vertices' x-position. Force stable sorting by comparing indices if
+       * the x-positions are equal. */
       indices = new Array(n);
 
       for(i = n; i--; )
         indices[i] = i;
 
       indices.sort(function(i, j) {
-        return vertices[j][0] - vertices[i][0];
+        var diff = vertices[j][0] - vertices[i][0];
+        return diff !== 0 ? diff : i - j;
       });
 
       /* Next, find the vertices of the supertriangle (which contains all other

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delaunay-fast",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Fast Delaunay Triangulation in JavaScript",
   "main": "delaunay.js",
   "scripts": {


### PR DESCRIPTION
The reason for this pull request is that Chrome does not have a stable sorting algorithm.
When comparing a triangulation done in chrome vs one made in IE, they might differ if there are "duplicate" x-positions in the vertices.
In this pull request the sorting of the indices falls back to comparing the index if the x-positions are equal.